### PR TITLE
Add MI-FGSM attack

### DIFF
--- a/torchattacks/__init__.py
+++ b/torchattacks/__init__.py
@@ -9,5 +9,6 @@ from .attacks.deepfool import DeepFool
 from .attacks.multiattack import MultiAttack
 from .attacks.ffgsm import FFGSM
 from .attacks.tpgd import TPGD
+from .attacks.mifgsm import MIFGSM
 
 __version__ = 2.5

--- a/torchattacks/attacks/__init__.py
+++ b/torchattacks/attacks/__init__.py
@@ -9,3 +9,4 @@ from .deepfool import DeepFool
 from .multiattack import MultiAttack
 from .ffgsm import FFGSM
 from .tpgd import TPGD
+from .mifgsm import MIFGSM

--- a/torchattacks/attacks/mifgsm.py
+++ b/torchattacks/attacks/mifgsm.py
@@ -67,6 +67,6 @@ class MIFGSM(Attack):
             ).float() * b
             images = torch.clamp(c, max=1).detach()
 
-        adv_images = images
+        adv_images = torch.clamp(images, min=0.0, max=1.0)
 
         return adv_images

--- a/torchattacks/attacks/mifgsm.py
+++ b/torchattacks/attacks/mifgsm.py
@@ -1,0 +1,75 @@
+import torch
+import torch.nn as nn
+
+from ..attack import Attack
+
+
+class MIFGSM(Attack):
+    r"""
+    MI-FGSM in the paper 'Boosting Adversarial Attacks with Momentum'
+    [https://arxiv.org/abs/1710.06081]
+
+    Distance Measure : Linf
+
+    Arguments:
+        model (nn.Module): model to attack.
+        eps (float): maximum perturbation. (DEFALUT : 8/255)
+        decay (float): momentum factor. (DEFAULT : 1.0)
+        steps (int): number of iterations. (DEFAULT: 5)
+
+    Shape:
+        - images: :math:`(N, C, H, W)` where `N = number of batches`, `C = number of channels`,        `H = height` and `W = width`. It must have a range [0, 1].
+        - labels: :math:`(N)` where each value :math:`y_i` is :math:`0 \leq y_i \leq` `number of labels`.
+        - output: :math:`(N, C, H, W)`.
+
+    Examples::
+        >>> attack = torchattacks.MIFGSM(model, eps=8/255, decay=1.0, steps=5)
+        >>> adv_images = attack(images, labels)
+
+    """
+
+    def __init__(self, model, eps=8 / 255, decay=1.0, steps=5):
+        super(MIFGSM, self).__init__("MIFGSM", model)
+        self.eps = eps
+        self.steps = steps
+        self.decay = decay
+        self.alpha = self.eps / self.steps
+
+    def forward(self, images, labels):
+        r"""
+        Overridden.
+        """
+        images = images.to(self.device)
+        labels = labels.to(self.device)
+        labels = self._transform_label(images, labels)
+        loss = nn.CrossEntropyLoss()
+        momentum = 0.0
+
+        for i in range(self.steps):
+            images.requires_grad = True
+            outputs = self.model(images)
+
+            cost = loss(outputs, labels).to(self.device)
+            grad = torch.autograd.grad(
+                cost, images, retain_graph=False, create_graph=False
+            )[0]
+            grad_norm = torch.norm(grad, p=1)
+            if self._targeted > 0:
+                grad /= grad_norm
+            else:
+                grad = cost / grad_norm
+            grad += momentum * self.decay
+            momentum = grad
+
+            adv_images = images + self._targeted * self.alpha * grad.sign()
+
+            a = torch.clamp(images - self.eps, min=0)
+            b = (adv_images >= a).float() * adv_images + (a > adv_images).float() * a
+            c = (b > images + self.eps).float() * (images + self.eps) + (
+                images + self.eps >= b
+            ).float() * b
+            images = torch.clamp(c, max=1).detach()
+
+        adv_images = images
+
+        return adv_images


### PR DESCRIPTION
# Description

Add a new white-box attack algorithm  [MI-FGSM](https://arxiv.org/abs/1710.06081),  which won the first places in NIPS 2017 Non-targeted Adversarial Attack and Targeted Adversarial Attack competitions.

# Type of change

- a new mifgsm.py under torchattacks/attacks/
- import statements in torchattacks/__init__.py and torchattacks/attacks/__init__.py

# Test

I run this attack on ubuntu18+python3.7.7+pytorch1.6, and successfully generated 6841/10000 targeted adv images and 1400/10000 untarged adv images in cifar10 test set, with eps=8/255, decay=0.1, steps=5.