### PR TITLE
Check the number of attacks passed to MultiAttack

### DIFF
--- a/torchattacks/attacks/multiattack.py
+++ b/torchattacks/attacks/multiattack.py
@@ -26,6 +26,8 @@ class MultiAttack(Attack):
         for attack in attacks:
             ids.append(id(attack.model))
 
+        if len(attacks) == 0:
+            raise ValueError("At least one attack should be provided.")
         if len(set(ids)) != 1:
             raise ValueError("At least one of attacks is referencing a different model.")
 


### PR DESCRIPTION
This PR simply adds a sanity check on the number of attacks passed to MultiAttack.

Due to a bug in my code, I gave an empty list of attacks to MultiAttack. I got a confusing error message stating that "at least one of attacks is referencing a different model". This PR should make this case more explicit. :) 


Thanks for your great work on this very useful library!