### PR TITLE
Update cw.py

### DIFF
--- a/torchattacks/attacks/cw.py
+++ b/torchattacks/attacks/cw.py
@@ -122,7 +122,7 @@ class CW(Attack):
 
     # f-function in the paper
     def f(self, outputs, labels):
-        one_hot_labels = torch.eye(len(outputs[0]))[labels].to(self.device)
+        one_hot_labels = torch.eye(len(outputs[0])).to(self.device)[labels]
 
         i, _ = torch.max((1-one_hot_labels)*outputs, dim=1) # get the second largest logit
         j = torch.masked_select(outputs, one_hot_labels.bool()) # get the largest logit


### PR DESCRIPTION
The created tensor one_hot_labels was raising the following error when running on GPU:
"RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)"

## PR Type and Checklist
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] FIX BUG
	- [ ] Check CURRENT and PREVIOUS [ISSUES](https://github.com/Harry24k/adversarial-attacks-pytorch/issues)..
	- [ ] Check [WORFLOW](https://github.com/Harry24k/adversarial-attacks-pytorch/actions) result  after PR.
- [ ] ADD ATTACK
	- [ ] DEFAULT values of arguments should be given except `model`.
	- [ ] Classname should be given as CamelCase.
	- [ ] Python file name should be SMALL letters of the classname.
	- [ ] Add attack in [__init__.py](https://github.com/Harry24k/adversarial-attacks-pytorch/blob/master/torchattacks/__init__.py)
	- [ ] Check `supported_mode` wheter the attack supports targeted mode.
	- [ ] [README.md](https://github.com/Harry24k/adversarial-attacks-pytorch/blob/master/README.md)  should be updated.
	- [ ] Check [WORFLOW](https://github.com/Harry24k/adversarial-attacks-pytorch/actions) result  after PR.
- [ ] Other... Please describe:

